### PR TITLE
Add Interval<-->TimeDelta support

### DIFF
--- a/agatesql/table.py
+++ b/agatesql/table.py
@@ -2,7 +2,6 @@
 
 import decimal
 import datetime
-import six
 import agate
 from sqlalchemy import Column, MetaData, Table, create_engine
 from sqlalchemy.engine import Connection
@@ -14,7 +13,7 @@ SQL_TYPE_MAP = {
     agate.Number: DECIMAL,
     agate.Date: DATE,
     agate.DateTime: DATETIME,
-    # agate.TimeDelta
+    agate.TimeDelta: Interval,
     agate.Text: VARCHAR
 }
 
@@ -48,15 +47,23 @@ class TableSQL(object):
             py_type = sql_column.type.python_type
 
             if py_type in [int, float, decimal.Decimal]:
+                if py_type is float:
+                    sql_column.type.asdecimal = True
                 column_types.append(agate.Number())
             elif py_type is bool:
                 column_types.append(agate.Boolean())
+<<<<<<< Updated upstream
             elif issubclass(py_type, six.string_types):
+=======
+            elif py_type in [str, unicode]:
+>>>>>>> Stashed changes
                 column_types.append(agate.Text())
             elif py_type is datetime.date:
                 column_types.append(agate.Date())
             elif py_type is datetime.datetime:
                 column_types.append(agate.DateTime())
+            elif py_type is datetime.timedelta:
+                column_types.append(agate.TimeDelta())
             else:
                 raise ValueError('Unsupported sqlalchemy column type: %s' % type(sql_column.type))
 

--- a/agatesql/table.py
+++ b/agatesql/table.py
@@ -52,11 +52,7 @@ class TableSQL(object):
                 column_types.append(agate.Number())
             elif py_type is bool:
                 column_types.append(agate.Boolean())
-<<<<<<< Updated upstream
             elif issubclass(py_type, six.string_types):
-=======
-            elif py_type in [str, unicode]:
->>>>>>> Stashed changes
                 column_types.append(agate.Text())
             elif py_type is datetime.date:
                 column_types.append(agate.Date())


### PR DESCRIPTION
Well this was fun. Interval(INTERVAL) is a many headed beast in SQLAlchemy. The patch adds code to deal with the fact that what interval type is used is dependent  on the database dialect. For those cases(postgresql, oracle) where there is native support use the native version and fake a python_type(datetime.timedelta) as that is not set in the native types. For the generic type it is set an so just use it, as it is datetime.timedelta also.  This deals with the from_sql case. For the to_sql case set the interval type using the dialect information from connection. To make all this happen create INTERVAL_MAP as lookup for dialect and interval type.